### PR TITLE
Fixed SSL verification for DECADA Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ For more information, visit https://siot.gov.sg/tech-stack/manuca/overview/
  * Clone the repository onto local disk: 
     `git clone --recurse-submodules https://github.com/GovTechSIOT/stack-manuca-os.git`
  * Toggle operating modes in mbed_app.json
- * [Temporary due to DECADA Cloud migration] Disable SSL Verification by changing mbed-os/features/netsocket/TLSSocketWrapper.cpp line 569 to `mbedtls_ssl_conf_authmode(get_ssl_config(), MBEDTLS_SSL_VERIFY_NONE);`
  * Compile the binary (https://siot.gov.sg/starter-kit/build-and-flash-sw/)
  * Copy the binary file (.bin) into the MANUCA DK via programmer (eg. stlink v3).
  

--- a/src/BootManager/boot_manager.cpp
+++ b/src/BootManager/boot_manager.cpp
@@ -11,7 +11,7 @@
 RawSerial pc(USBTX, USBRX, 115200);
 
 const uint8_t boot_timeout_sec = 5;    
-const std::string sdk_ver = "1.01";
+const std::string sdk_ver = "1.1.0";
 const uint8_t max_login_attempts = 3;
 const std::string poll_rate_ms = "10000";
 const std::string boot_login_pw = "stackx2019";

--- a/src/CommunicationFrontEnd/MQTT/MQTT_server_setting.h
+++ b/src/CommunicationFrontEnd/MQTT/MQTT_server_setting.h
@@ -2,7 +2,7 @@
 #define MQTT_SERVER_SETTING_H
 
 #if MBED_CONF_APP_USE_TLS == 1
-const int MQTT_SERVER_PORT = 18883;
+const int MQTT_SERVER_PORT = 18885;
 #else
 /* No TLS */
 const int MQTT_SERVER_PORT = 1883;

--- a/src/CryptoEngine/crypto_engine.cpp
+++ b/src/CryptoEngine/crypto_engine.cpp
@@ -47,29 +47,26 @@ static unsigned char 						mbedtls_csr_pem[4096];
 
 /**
  *  @brief  Generate CSR for retrieving client certificate from decada.
- *  @author Goh Kok Boon
- *  @param  decada_root_ca   Root CA from decada
+ *  @author Goh Kok Boon, Lau Lee Hong
+ *  @param  timestamp   Current unix epoch timestamp (in miliseconds)
  *  @return Return PEM-formatted CSR
  */
-std::string GenerateCsr(std::string decada_root_ca, std::string timestamp)
+std::string GenerateCsr(std::string timestamp)
 {
-    ssl_ca_params ssl_ca_info; 
-    int rc = X509CADecoder(decada_root_ca, ssl_ca_info);
-    std::string csr_info = "C=" +  ssl_ca_info.country_name + ", ST=" +  ssl_ca_info.state_name +
-	 ", L=Singapore, O=" +  ssl_ca_info.org_name + ", OU=Decada, CN=" + device_uuid + timestamp;
+     std::string csr_info = "C=SG, ST=Singapore, L=Singapore, O=DECADA, OU=DECADA CA, CN=" + device_uuid + timestamp;
 
-    const char* mbedtls_subject_name = csr_info.c_str(); 
+	const char* mbedtls_subject_name = csr_info.c_str(); 
 
-    if (GenerateRSAKeypair() == 1)
-    {
-	    mbedtls_x509write_csr_init(&mbedtls_csr_request);
-	    mbedtls_x509write_csr_set_md_alg(&mbedtls_csr_request, MBEDTLS_MD_SHA256);
-	    mbedtls_ctr_drbg_init(&mbedtls_ctrdrbg);
-	    memset(mbedtls_private_key, 0, sizeof(mbedtls_private_key));
+	if (GenerateRSAKeypair() == 1)
+	{
+		mbedtls_x509write_csr_init(&mbedtls_csr_request);
+		mbedtls_x509write_csr_set_md_alg(&mbedtls_csr_request, MBEDTLS_MD_SHA256);
+		mbedtls_ctr_drbg_init(&mbedtls_ctrdrbg);
+		memset(mbedtls_private_key, 0, sizeof(mbedtls_private_key));
 
         /* Seeding Random Number */
-	    mbedtls_entropy_init(&mbedtls_entropy);
-	    rc = mbedtls_ctr_drbg_seed(&mbedtls_ctrdrbg, mbedtls_entropy_func, &mbedtls_entropy, (const unsigned char *)mbedtls_pers, strlen(mbedtls_pers));
+		mbedtls_entropy_init(&mbedtls_entropy);
+		int rc = mbedtls_ctr_drbg_seed(&mbedtls_ctrdrbg, mbedtls_entropy_func, &mbedtls_entropy, (const unsigned char *)mbedtls_pers, strlen(mbedtls_pers));
 
 	    if (rc == 0)
 	    {

--- a/src/CryptoEngine/crypto_engine.cpp
+++ b/src/CryptoEngine/crypto_engine.cpp
@@ -53,8 +53,7 @@ static unsigned char 						mbedtls_csr_pem[4096];
  */
 std::string GenerateCsr(std::string timestamp)
 {
-     std::string csr_info = "C=SG, ST=Singapore, L=Singapore, O=DECADA, OU=DECADA CA, CN=" + device_uuid + timestamp;
-
+    std::string csr_info = "C=SG, ST=Singapore, L=Singapore, O=DECADA, OU=DECADA CA, CN=" + device_uuid + timestamp;
 	const char* mbedtls_subject_name = csr_info.c_str(); 
 
 	if (GenerateRSAKeypair() == 1)

--- a/src/CryptoEngine/crypto_engine.h
+++ b/src/CryptoEngine/crypto_engine.h
@@ -27,7 +27,7 @@ typedef struct {
 } ssl_ca_params;
 
 int GenerateRSAKeypair(void);
-std::string GenerateCsr(std::string decada_root_ca, std::string timestamp);
+std::string GenerateCsr(std::string timestamp);
 std::string CSRPEMFormatter(std::string s);
 std::string CAPEMFormatter(std::string s);
 bool X509IssuerInfo (char* buf, size_t size, const mbedtls_x509_crt* crt);

--- a/src/DecadaManager/decada_manager.cpp
+++ b/src/DecadaManager/decada_manager.cpp
@@ -20,31 +20,7 @@
  *
  * To add more root certificates, just concatenate them.
  */
-const char SSL_CA_STORE_PEM[] =  "-----BEGIN CERTIFICATE-----\n"
-    "MIIEHTCCAwWgAwIBAgIQToEtioJl4AsC7j41AkblPTANBgkqhkiG9w0BAQUFADCB\n"
-    "gTELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G\n"
-    "A1UEBxMHU2FsZm9yZDEaMBgGA1UEChMRQ09NT0RPIENBIExpbWl0ZWQxJzAlBgNV\n"
-    "BAMTHkNPTU9ETyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjEyMDEwMDAw\n"
-    "MDBaFw0yOTEyMzEyMzU5NTlaMIGBMQswCQYDVQQGEwJHQjEbMBkGA1UECBMSR3Jl\n"
-    "YXRlciBNYW5jaGVzdGVyMRAwDgYDVQQHEwdTYWxmb3JkMRowGAYDVQQKExFDT01P\n"
-    "RE8gQ0EgTGltaXRlZDEnMCUGA1UEAxMeQ09NT0RPIENlcnRpZmljYXRpb24gQXV0\n"
-    "aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0ECLi3LjkRv3\n"
-    "UcEbVASY06m/weaKXTuH+7uIzg3jLz8GlvCiKVCZrts7oVewdFFxze1CkU1B/qnI\n"
-    "2GqGd0S7WWaXUF601CxwRM/aN5VCaTwwxHGzUvAhTaHYujl8HJ6jJJ3ygxaYqhZ8\n"
-    "Q5sVW7euNJH+1GImGEaaP+vB+fGQV+useg2L23IwambV4EajcNxo2f8ESIl33rXp\n"
-    "+2dtQem8Ob0y2WIC8bGoPW43nOIv4tOiJovGuFVDiOEjPqXSJDlqR6sA1KGzqSX+\n"
-    "DT+nHbrTUcELpNqsOO9VUCQFZUaTNE8tja3G1CEZ0o7KBWFxB3NH5YoZEr0ETc5O\n"
-    "nKVIrLsm9wIDAQABo4GOMIGLMB0GA1UdDgQWBBQLWOWLxkwVN6RAqTCpIb5HNlpW\n"
-    "/zAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zBJBgNVHR8EQjBAMD6g\n"
-    "PKA6hjhodHRwOi8vY3JsLmNvbW9kb2NhLmNvbS9DT01PRE9DZXJ0aWZpY2F0aW9u\n"
-    "QXV0aG9yaXR5LmNybDANBgkqhkiG9w0BAQUFAAOCAQEAPpiem/Yb6dc5t3iuHXIY\n"
-    "SdOH5EOC6z/JqvWote9VfCFSZfnVDeFs9D6Mk3ORLgLETgdxb8CPOGEIqB6BCsAv\n"
-    "IC9Bi5HcSEW88cbeunZrM8gALTFGTO3nnc+IlP8zwFboJIYmuNg4ON8qa90SzMc/\n"
-    "RxdMosIGlgnW2/4/PEZB31jiVg88O8EckzXZOFKs7sjsLjBOlDW0JB9LeGna8gI4\n"
-    "zJVSk/BwJVmcIGfE7vmLV2H0knZ9P4SNVbfo5azV8fUZVqZa+5Acr5Pr5RzUZ5dd\n"
-    "BA6+C4OmF4O5MBKgxTMVBbkN+8cFduPYSo38NBejxiEovjBFMR7HeL5YYTisO+IB\n"
-    "ZQ==\n"
-    "-----END CERTIFICATE-----\n"
+const char SSL_CA_STORE_PEM[] =  
     "-----BEGIN CERTIFICATE-----\n"
     "MIIF2DCCA8CgAwIBAgIQTKr5yttjb+Af907YWwOGnTANBgkqhkiG9w0BAQwFADCB\n"
     "hTELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G\n"
@@ -78,22 +54,6 @@ const char SSL_CA_STORE_PEM[] =  "-----BEGIN CERTIFICATE-----\n"
     "QOhTsiedSrnAdyGN/4fy3ryM7xfft0kL0fJuMAsaDk527RH89elWsn2/x20Kk4yl\n"
     "0MC2Hb46TpSi125sC8KKfPog88Tk5c0NqMuRkrF8hey1FGlmDoLnzc7ILaZRfyHB\n"
     "NVOFBkpdn627G190\n"
-    "-----END CERTIFICATE-----\n"
-    "-----BEGIN CERTIFICATE-----\n"
-    "MIICiTCCAg+gAwIBAgIQH0evqmIAcFBUTAGem2OZKjAKBggqhkjOPQQDAzCBhTEL\n"
-    "MAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UE\n"
-    "BxMHU2FsZm9yZDEaMBgGA1UEChMRQ09NT0RPIENBIExpbWl0ZWQxKzApBgNVBAMT\n"
-    "IkNPTU9ETyBFQ0MgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMDgwMzA2MDAw\n"
-    "MDAwWhcNMzgwMTE4MjM1OTU5WjCBhTELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdy\n"
-    "ZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UEBxMHU2FsZm9yZDEaMBgGA1UEChMRQ09N\n"
-    "T0RPIENBIExpbWl0ZWQxKzApBgNVBAMTIkNPTU9ETyBFQ0MgQ2VydGlmaWNhdGlv\n"
-    "biBBdXRob3JpdHkwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQDR3svdcmCFYX7deSR\n"
-    "FtSrYpn1PlILBs5BAH+X4QokPB0BBO490o0JlwzgdeT6+3eKKvUDYEs2ixYjFq0J\n"
-    "cfRK9ChQtP6IHG4/bC8vCVlbpVsLM5niwz2J+Wos77LTBumjQjBAMB0GA1UdDgQW\n"
-    "BBR1cacZSBm8nZ3qQUfflMRId5nTeTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/\n"
-    "BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjEA7wNbeqy3eApyt4jf/7VGFAkK+qDm\n"
-    "fQjGGoe9GKhzvSbKYAydzpmfz1wPMOG+FDHqAjAU9JM8SaczepBGR7NjfRObTrdv\n"
-    "GDeAU/7dIOA1mjbRxwG55tzd8/8dLDoWV9mSOdY=\n"
     "-----END CERTIFICATE-----\n";
 
 const std::string decada_product_key = MBED_CONF_APP_DECADA_PRODUCT_KEY;
@@ -105,29 +65,11 @@ const std::string api_url = MBED_CONF_APP_DECADA_API_URL;
 /**
  *  @brief  Gets DECADA SSL Root CA for MQTT Connection.
  *  @author Lau Lee Hong
- *  @param  network  Pointer to network object 
- *  @return PEM-formatted SSL Root CA
+ *  @return PEM-formatted SSL Root CA - COMODO Cert.
  */
-std::string GetDecadaRootCA(NetworkInterface* network)
+std::string GetDecadaRootCA(void)
 {
-    HttpsRequest* request = new HttpsRequest(network, SSL_CA_STORE_PEM, HTTP_GET, MBED_CONF_APP_DECADA_CA_URL);
-    request->set_header("Content-Type", "application/json;charset=UTF-8");
- 
-    HttpResponse* response = request->send();
-    
-    if (!response) 
-    {
-        tr_warn("HttpRequest failed (error code %d)");
-        delete request;
-        return "invalid";
-    }
-    else
-    {
-        std::string root_ca = response->get_body_as_string();
-        root_ca = CAPEMFormatter(root_ca);
-        delete request;
-        return root_ca;
-    }
+    return SSL_CA_STORE_PEM;
 }
 
 /**
@@ -243,7 +185,7 @@ std::string ApplyMqttCertificate(NetworkInterface* network, std::string decada_r
 {    
     const std::string timestamp_ms = MsPaddingIntToString(RawRtcTimeNow());
     
-    const std::string ssl_csr = GenerateCsr(decada_root_ca, timestamp_ms);
+    const std::string ssl_csr = GenerateCsr(timestamp_ms);
     const std::string body_sanitized = CSRPEMFormatter(ssl_csr);    
 
     /* Sort in ASCII order */

--- a/src/DecadaManager/decada_manager.h
+++ b/src/DecadaManager/decada_manager.h
@@ -20,7 +20,7 @@
 #include <string>
 #include "mbed.h"
 
-std::string GetDecadaRootCA(NetworkInterface* network);
+std::string GetDecadaRootCA(void);
 std::string CheckDeviceRegistrationStatus(NetworkInterface* network);
 std::string RegisterDeviceToDecada(NetworkInterface* network, std::string device_name);
 std::string ApplyMqttCertificate(NetworkInterface* network, std::string decada_root_ca);

--- a/threads/communications_thread.cpp
+++ b/threads/communications_thread.cpp
@@ -73,7 +73,7 @@ void communications_controller_thread(void)
     UpdateRtc(ntp);
 
     /* Get DECADA root CA cert */
-    decada_root_ca = GetDecadaRootCA(network);
+    decada_root_ca = GetDecadaRootCA();
     tr_info("Root CA is retrieved from decada.");
 
     device_secret = CheckDeviceRegistrationStatus(network);


### PR DESCRIPTION
* Parity with SENP-102 (ticket mention for internal tracking).
* DECADA Client is able to perform SSL verification for communication with cloud instance.
* Users using previous settings must ensure they set their mbed-os/feature/netsocket/TLSSocketWrapper.cpp line #569 to `mbedtls_ssl_conf_authmode(get_ssl_config(), MBEDTLS_SSL_VERIFY_REQUIRED);`
