### PR TITLE
Corrected sensor thread polling interval

### DIFF
--- a/threads/sensor_thread.cpp
+++ b/threads/sensor_thread.cpp
@@ -131,7 +131,7 @@ void sensor_thread(void)
         }
         poll_counter++;
 
-        if (poll_counter > current_poll_count)
+        if (poll_counter >= current_poll_count)
         {
             poll_counter = 0;
         }


### PR DESCRIPTION
The sensor thread polling interval is longer than expected.

**For example:**
Suppose our `current_cycle_interval` equals `sensor_thread_sleep_ms` (1000 ms) then we expect the sensor thread to read the tmp75 value on every loop iteration, but the current behavior reads on every **two** iterations (2000 ms). So, if we set the sensor poll rate to 10 seconds, it actually polls on every 11 seconds.